### PR TITLE
Fixes to work on Mac OSX 10.10.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ debug: OPT= $(DEBUG)
 debug: $(TARGET)
 
 clean:
-	$(RM) $(OBJS) $(TARGET) 
+	$(RM) $(OBJS) $(TARGET)
 
 install: $(TARGET)
-	strip --strip-unneeded $(TARGET)
+	strip $(TARGET)
 	cp $(TARGET) $(INSTALL_DIR)/$(TARGET)

--- a/main.c
+++ b/main.c
@@ -54,6 +54,17 @@
 #define IN_RANGE(MIN, MAX, N)    \
     ((N) >= (MIN) && (N) <= (MAX))
 
+char *strdup(const char *str)
+{
+    int n = strlen(str) + 1;
+    char *dup = malloc(n);
+    if(dup)
+    {
+        strcpy(dup, str);
+    }
+    return dup;
+}
+
 static char *generate(size_t len, char *table, int fd);
 static void die(char *msg, int status);
 static char *str_rmdup(const char *s);


### PR DESCRIPTION
Details of compile error encountered

```
gcc -std=c99 -O3 -Wall -Werror -Wextra -pedantic  -c main.c -o main.o
main.c: In function 'main':
main.c:159:13: error: implicit declaration of function 'strdup' [-Werror=implicit-function-declaration]
             if (!(pass_prefix = strdup(optarg))) {
             ^
main.c:159:31: error: assignment makes pointer from integer without a cast [-Werror]
             if (!(pass_prefix = strdup(optarg))) {
                               ^
cc1: all warnings being treated as errors
make: *** [main.o] Error 1
```
